### PR TITLE
Mark the ports as fixed, use needs_exposed_ports to get a warning during yunohost diagnosis

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -64,17 +64,22 @@ main.show_tile = false
 main.allowed = "visitors"
 
 [resources.ports]
-api.default = 21114
+#api.default = 21114
 hbbs.default = 21115
 hbbs.exposed = "TCP"
+hbbs.fixed = true
 hbbsbis.default = 21116
 hbbsbis.exposed = "Both"
+hbbsbis.fixed = true
 hbbster.default = 21118
 hbbster.exposed = "TCP"
+hbbster.fixed = true
 hbbr.default = 21117
 hbbr.exposed = "TCP"
+hbbr.fixed = true
 hbbrbis.default = 21119
 hbbrbis.exposed = "TCP"
+hbbrbis.fixed = true
 
 [resources.apt]
 packages = "sqlite3"

--- a/scripts/install
+++ b/scripts/install
@@ -21,8 +21,11 @@ ynh_script_progression "Adding system configurations related to $app..."
 ynh_config_add_systemd --service=rustdeskrelay --template=rustdeskrelay.service
 ynh_config_add_systemd --service=rustdesksignal --template=rustdesksignal.service
 
-yunohost service add rustdeskrelay --description="Rustdesk Relay Server" --log="/var/log/$app/$app.log"
-yunohost service add rustdesksignal --description="Rustdesk Signal Server" --log="/var/log/$app/$app.log"
+# According to the doc (no web client for now) https://rustdesk.com/docs/en/self-host/rustdesk-server-oss/install/#ports
+# TCP: 21115 21116 21117
+# UDP: 21116
+yunohost service add rustdeskrelay --description="Rustdesk Relay Server" --log="/var/log/$app/$app.log" --needs_exposed_ports 21117
+yunohost service add rustdesksignal --description="Rustdesk Signal Server" --log="/var/log/$app/$app.log" --needs_exposed_ports 21115 21116
 
 mkdir -p /var/log/$app
 touch /var/log/$app/$app.log

--- a/scripts/remove
+++ b/scripts/remove
@@ -15,8 +15,8 @@ if ynh_hide_warnings yunohost service status rustdesksignal >/dev/null; then
 	yunohost service remove rustdesksignal
 fi
 
-ynh_config_remove_systemdrustdeskrelay
-ynh_config_remove_systemdrustdesksignal
+ynh_config_remove_systemd rustdeskrelay
+ynh_config_remove_systemd rustdesksignal
 
 ynh_config_remove_logrotate
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -29,8 +29,11 @@ touch /var/log/$app/$app.log
 
 ynh_restore "/etc/logrotate.d/$app"
 
-yunohost service add rustdeskrelay --description="Rustdesk Relay Server" --log="/var/log/$app/$app.log"
-yunohost service add rustdesksignal --description="Rustdesk Signal Server" --log="/var/log/$app/$app.log"
+# According to the doc (no web client for now) https://rustdesk.com/docs/en/self-host/rustdesk-server-oss/install/#ports
+# TCP: 21115 21116 21117
+# UDP: 21116
+yunohost service add rustdeskrelay --description="Rustdesk Relay Server" --log="/var/log/$app/$app.log" --needs_exposed_ports 21117
+yunohost service add rustdesksignal --description="Rustdesk Signal Server" --log="/var/log/$app/$app.log" --needs_exposed_ports 21115 21116
 
 #=================================================
 # RELOAD NGINX AND PHP-FPM OR THE APP SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -29,8 +29,11 @@ ynh_script_progression "Upgrading system configurations related to $app..."
 ynh_config_add_systemd --service=rustdeskrelay --template=rustdeskrelay.service
 ynh_config_add_systemd --service=rustdesksignal --template=rustdesksignal.service
 
-yunohost service add rustdeskrelay --description="Rustdesk Relay Server" --log="/var/log/$app/$app.log"
-yunohost service add rustdesksignal --description="Rustdesk Signal Server" --log="/var/log/$app/$app.log"
+# According to the doc (no web client for now) https://rustdesk.com/docs/en/self-host/rustdesk-server-oss/install/#ports
+# TCP: 21115 21116 21117
+# UDP: 21116
+yunohost service add rustdeskrelay --description="Rustdesk Relay Server" --log="/var/log/$app/$app.log" --needs_exposed_ports 21117
+yunohost service add rustdesksignal --description="Rustdesk Signal Server" --log="/var/log/$app/$app.log" --needs_exposed_ports 21115 21116
 
 #=================================================
 # START SYSTEMD SERVICE


### PR DESCRIPTION
## Problem

- *We don't have any warning during the diagnosis about ports unreachable*

## Solution

- *Use the param `needs_exposed_ports` (no way to tell the admin if it's TCP or UDP)*
- *Mark ports as fixed because it's complicated to change them, and they are linked to each others*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on <https://ci-apps-dev.yunohost.org/> *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
